### PR TITLE
Add jest coverage script (Resolves Issue #13)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "docs": "jsdoc -c jsdoc.conf.json --readme README.md --destination dist/api",
     "test:size": "bundlesize",
     "test": "jest ./test/test.js || true",
+    "test:coverage": "jest --coverage --watchAll=false",
     "lint": "eslint ."
   },
   "husky": {


### PR DESCRIPTION
This adds a script in `package.json` for the jest coverage report to run.

The coverage directory was already in the `.gitignore`.